### PR TITLE
Acrescentada a verificacao se o pedido foi pago antes de cancelar

### DIFF
--- a/app/controllers/spree/bank_slips_controller.rb
+++ b/app/controllers/spree/bank_slips_controller.rb
@@ -18,7 +18,9 @@ module Spree
           # Cancela o pagamento e o pedido
           when :canceled, :expired
             @slip.payment.void_transaction!
-            @slip.order.cancel!
+            # Pode ser que o pedido tenha sido completo por outro pagamento
+            # esse e o motivo dessa verificacao
+            @slip.order.cancel! if @slip.order.payment_state == 'balance_due'
         end
       end
       render nothing: true, status: 200


### PR DESCRIPTION
Já que é possível fazer outro pagamento para a compra, o vencimento do boleto não deve cancelar ela em todos os casos. Por isso foi verificado se ele está como "balance_due"